### PR TITLE
Cache API discovery info.

### DIFF
--- a/dynamic/clientset/dynamic_clientset.go
+++ b/dynamic/clientset/dynamic_clientset.go
@@ -32,10 +32,10 @@ import (
 
 type Clientset struct {
 	config    rest.Config
-	resources dynamicdiscovery.ResourceDiscovery
+	resources *dynamicdiscovery.ResourceMap
 }
 
-func New(config *rest.Config, resources dynamicdiscovery.ResourceDiscovery) *Clientset {
+func New(config *rest.Config, resources *dynamicdiscovery.ResourceMap) *Clientset {
 	return &Clientset{
 		config:    *config,
 		resources: resources,

--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -39,31 +38,47 @@ import (
 	dynamicdiscovery "k8s.io/metacontroller/dynamic/discovery"
 )
 
-func resyncAll(config *rest.Config, mcInformerFactory internalinformers.SharedInformerFactory) error {
-	// Discover all supported resources.
-	dc, err := discovery.NewDiscoveryClientForConfig(config)
-	if err != nil {
-		return fmt.Errorf("can't create discovery client: %v", err)
-	}
-	resources, err := dc.ServerResources()
-	if err != nil {
-		return fmt.Errorf("can't discover resources: %v", err)
-	}
-	dynClient := dynamicclientset.New(config, dynamicdiscovery.NewResourceMap(resources))
+var (
+	discoveryInterval = flag.Duration("discovery-interval", 30*time.Second, "How often to refresh discovery cache to pick up newly-installed resources")
+	informerResync    = flag.Duration("informer-resync", 5*time.Minute, "Default resync period for shared informer caches")
+)
 
-	// Sync all CompositeController objects.
+func startResyncLoop(dynClient *dynamicclientset.Clientset, mcInformerFactory internalinformers.SharedInformerFactory) (cancel func()) {
+	stop := make(chan struct{})
+	done := make(chan struct{})
+
 	ccLister := mcInformerFactory.Metacontroller().V1alpha1().CompositeControllers().Lister()
-	if err := composite.SyncAll(dynClient, ccLister); err != nil {
-		glog.Errorf("can't sync CompositeControllers: %v", err)
-	}
-
-	// Sync all InitializerController objects.
 	icLister := mcInformerFactory.Metacontroller().V1alpha1().InitializerControllers().Lister()
-	if err := initializer.SyncAll(dynClient, icLister); err != nil {
-		glog.Errorf("can't sync InitializerControllers: %v", err)
-	}
 
-	return nil
+	go func() {
+		defer close(done)
+
+		// This interval isn't configurable because polling is going away soon.
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				// Sync all CompositeController objects.
+				if err := composite.SyncAll(dynClient, ccLister); err != nil {
+					glog.Errorf("can't sync CompositeControllers: %v", err)
+				}
+
+				// Sync all InitializerController objects.
+				if err := initializer.SyncAll(dynClient, icLister); err != nil {
+					glog.Errorf("can't sync InitializerControllers: %v", err)
+				}
+			}
+		}
+	}()
+
+	return func() {
+		close(stop)
+		<-done
+	}
 }
 
 func main() {
@@ -74,12 +89,18 @@ func main() {
 		glog.Fatal(err)
 	}
 
+	// Periodically refresh discovery to pick up newly-installed resources.
+	dc := discovery.NewDiscoveryClientForConfigOrDie(config)
+	resources := dynamicdiscovery.NewResourceMap(dc)
+	stopDiscoveryRefresh := resources.Start(*discoveryInterval)
+	defer stopDiscoveryRefresh()
+
 	// Create informerfactory for metacontroller api objects.
 	mcClient, err := internalclient.NewForConfig(config)
 	if err != nil {
 		glog.Fatalf("Can't create client for api %s: %v", v1alpha1.SchemeGroupVersion, err)
 	}
-	mcInformerFactory := internalinformers.NewSharedInformerFactory(mcClient, 5*time.Minute)
+	mcInformerFactory := internalinformers.NewSharedInformerFactory(mcClient, *informerResync)
 
 	// Initialize informers.
 	mcInformerFactory.Metacontroller().V1alpha1().CompositeControllers().Informer()
@@ -87,44 +108,27 @@ func main() {
 	mcInformerFactory.Start(nil)
 
 	// Wait for the caches to be synced before starting the loop.
-	glog.V(2).Info("Waiting for informers caches to sync")
+	glog.V(2).Info("Waiting for discovery and informer caches to sync")
 	if ok := cache.WaitForCacheSync(nil,
+		resources.HasSynced,
 		mcInformerFactory.Metacontroller().V1alpha1().CompositeControllers().Informer().HasSynced,
 		mcInformerFactory.Metacontroller().V1alpha1().InitializerControllers().Informer().HasSynced,
 	); !ok {
 		glog.Fatal("Failed to wait for caches to sync")
 	}
-	glog.V(2).Info("Informers caches synced")
+	glog.V(2).Info("Discovery and informer caches synced")
 
-	// Close 'stop' to begin shutdown. Wait for 'done' before terminating.
-	stop := make(chan struct{})
-	done := make(chan struct{})
+	// Create dynamic clientset (factory for dynamic clients).
+	dynClient := dynamicclientset.New(config, resources)
 
 	// Start polling in the background.
 	// TODO(kube-metacontroller#8): Replace with shared, dynamic informers.
-	go func() {
-		defer close(done)
+	stopResyncLoop := startResyncLoop(dynClient, mcInformerFactory)
+	defer stopResyncLoop()
 
-		ticker := time.NewTicker(5 * time.Second)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-stop:
-				return
-			case <-ticker.C:
-				if err := resyncAll(config, mcInformerFactory); err != nil {
-					glog.Errorf("sync: %v", err)
-				}
-			}
-		}
-	}()
-
-	// On SIGTERM, wait for a complete resync attempt to finish gracefully.
+	// On SIGTERM, execute deferred functions to shut down gracefully.
 	sigchan := make(chan os.Signal, 2)
 	signal.Notify(sigchan, os.Interrupt, syscall.SIGTERM)
 	sig := <-sigchan
 	glog.Infof("Received %q signal. Shutting down...", sig)
-	close(stop)
-	<-done
 }


### PR DESCRIPTION
For now, it's just polling at a fixed interval that's larger than the controller sync interval. It's also now in the background, so controllers don't have to wait for the discovery refresh every time before syncing.

If necessary, we can consider latency improvements in the future, such as refreshing on a cache miss or watching for new CRDs to become Established.

Closes #4