### PR TITLE
examples/catset: Add StatefulSet-style rolling update.

### DIFF
--- a/examples/catset/README.md
+++ b/examples/catset/README.md
@@ -1,6 +1,6 @@
 ## CatSet
 
-This is a reimplementation of StatefulSet (except for rolling updates) as a CompositeController.
+This is a reimplementation of StatefulSet (now including rolling updates) as a CompositeController.
 
 For this example, you need a cluster with a default storage class and a dynamic provisioner.
 

--- a/examples/catset/catset-controller.yaml
+++ b/examples/catset/catset-controller.yaml
@@ -21,9 +21,18 @@ spec:
   parentResource:
     apiVersion: ctl.enisoc.com/v1
     resource: catsets
+    revisionHistory:
+      fieldPaths:
+      - spec.template
   childResources:
   - apiVersion: v1
     resource: pods
+    updateStrategy:
+      method: RollingRecreate
+      statusChecks:
+        conditions:
+        - type: Ready
+          status: "True"
   - apiVersion: v1
     resource: persistentvolumeclaims
   clientConfig:

--- a/examples/catset/sync.js
+++ b/examples/catset/sync.js
@@ -98,7 +98,10 @@ module.exports = async function (context) {
         delete desiredPods[maxOrdinal];
       }
     }
-    desired.children.push(...Object.values(desiredPods));
+    // List Pods in descending order, since that determines rolling update order.
+    for (let ordinal of Object.keys(desiredPods).sort((a,b) => a-b).reverse()) {
+      desired.children.push(desiredPods[ordinal]);
+    }
 
     if (catset.spec.volumeClaimTemplates) {
       // Generate desired PVCs.


### PR DESCRIPTION
This enables the new rolling update feature (#21) for the CatSet example, so it's now a more complete replacement for StatefulSet.