### PR TITLE
examples/vitess: Enable rolling updates.

### DIFF
--- a/examples/vitess/hooks/sync-cell.jsonnet
+++ b/examples/vitess/hooks/sync-cell.jsonnet
@@ -114,9 +114,8 @@ function(request) {
   },
 
   // Child objects for this cell.
+  // List in the desired order for rolling updates.
   children:
-    keyspaces.desired +
-
     etcdClusters.desired +
 
     vtctldServices.desired +
@@ -128,5 +127,9 @@ function(request) {
 
     vttabletServices.desired +
 
-    vtctlclientJobs.desired,
+    vtctlclientJobs.desired +
+
+    // Update keyspaces last, after any cell-level updates.
+    keyspaces.desired
+    ,
 }

--- a/examples/vitess/hooks/sync-shard.jsonnet
+++ b/examples/vitess/hooks/sync-shard.jsonnet
@@ -25,17 +25,18 @@ function(request) {
     alias: self.cell + "-" + self.uidString,
     subdomain: "%s-vttablet-%s" % [self.cluster, self.cell],
   },
+  // List tablets in the desired order for rolling updates.
   local tabletSpecs = (
-    // "replica" type tablets
-    if "masterEligible" in observed.parent.spec.tablets then
-      local spec = tabletDefaults + observed.parent.spec.tablets.masterEligible;
-      [tabletSpec(spec + {type: "replica", index: i}) for i in std.range(0, spec.replicas - 1)]
-    else []
-  ) + (
     // "rdonly" type tablets
     if "batch" in observed.parent.spec.tablets then
       local spec = tabletDefaults + observed.parent.spec.tablets.batch;
       [tabletSpec(spec + {type: "rdonly", index: i}) for i in std.range(0, spec.replicas - 1)]
+    else []
+  ) + (
+    // "replica" type tablets
+    if "masterEligible" in observed.parent.spec.tablets then
+      local spec = tabletDefaults + observed.parent.spec.tablets.masterEligible;
+      [tabletSpec(spec + {type: "replica", index: i}) for i in std.range(0, spec.replicas - 1)]
     else []
   ),
 

--- a/examples/vitess/hooks/vtctlclient.libsonnet
+++ b/examples/vitess/hooks/vtctlclient.libsonnet
@@ -15,7 +15,6 @@ local metacontroller = import "metacontroller.libsonnet";
   jobs(observed, specs)::
     metacontroller.collection(observed, specs, "batch/v1", "Job", vtctlclient.job)
       + metacontroller.collectionFilter(vtctlclient.matchJob)
-      + metacontroller.collectionImmutable
       + {
         isComplete(specName)::
           local name = observed.parent.metadata.name + "-" + specName;

--- a/examples/vitess/hooks/vttablet.libsonnet
+++ b/examples/vitess/hooks/vttablet.libsonnet
@@ -12,8 +12,7 @@ local metacontroller = import "metacontroller.libsonnet";
   // Collections of vttablet objects.
   pods(observed, specs)::
     metacontroller.collection(observed, specs, "v1", "Pod", vttablet.pod)
-      + metacontroller.collectionFilter(vttablet.matchLabels)
-      + metacontroller.collectionImmutable,
+      + metacontroller.collectionFilter(vttablet.matchLabels),
   volumes(observed, specs)::
     metacontroller.collection(observed, specs, "v1", "PersistentVolumeClaim", vttablet.volume)
       + metacontroller.collectionFilter(vttablet.matchLabels),

--- a/examples/vitess/vitess-operator.yaml
+++ b/examples/vitess/vitess-operator.yaml
@@ -65,6 +65,14 @@ spec:
   childResources:
   - apiVersion: vitess.io/v1alpha1
     resource: vitesscells
+    updateStrategy:
+      method: RollingInPlace
+      statusChecks:
+        conditions:
+        - type: Ready
+          status: "True"
+        - type: Updated
+          status: "True"
   clientConfig:
     service:
       name: vitess-operator
@@ -84,16 +92,45 @@ spec:
   childResources:
   - apiVersion: v1
     resource: services
+    updateStrategy:
+      method: InPlace
   - apiVersion: v1
     resource: configmaps
+    updateStrategy:
+      method: InPlace
   - apiVersion: apps/v1beta2
     resource: deployments
+    updateStrategy:
+      method: RollingInPlace
+      statusChecks:
+        conditions:
+        - type: Available
+          status: "True"
+        - type: Progressing
+          status: "True"
+          reason: NewReplicaSetAvailable
   - apiVersion: batch/v1
     resource: jobs
+    updateStrategy:
+      method: Recreate
   - apiVersion: etcd.database.coreos.com/v1beta2
     resource: etcdclusters
+    updateStrategy:
+      method: RollingInPlace
+      statusChecks:
+        conditions:
+        - type: Available
+          status: "True"
   - apiVersion: vitess.io/v1alpha1
     resource: vitesskeyspaces
+    updateStrategy:
+      method: RollingInPlace
+      statusChecks:
+        conditions:
+        - type: Ready
+          status: "True"
+        - type: Updated
+          status: "True"
   clientConfig:
     service:
       name: vitess-operator
@@ -113,6 +150,14 @@ spec:
   childResources:
   - apiVersion: vitess.io/v1alpha1
     resource: vitessshards
+    updateStrategy:
+      method: RollingInPlace
+      statusChecks:
+        conditions:
+        - type: Ready
+          status: "True"
+        - type: Updated
+          status: "True"
   clientConfig:
     service:
       name: vitess-operator
@@ -132,6 +177,12 @@ spec:
   childResources:
   - apiVersion: v1
     resource: pods
+    updateStrategy:
+      method: RollingRecreate
+      statusChecks:
+        conditions:
+        - type: Ready
+          status: "True"
   - apiVersion: v1
     resource: persistentvolumeclaims
   clientConfig:


### PR DESCRIPTION
For now, tablet rollouts (part of the VitessShard controller) work similarly to StatefulSet updates. In a later PR, I plan to add rollout hooks that will allow for planned reparenting before updating the master tablet.

cc @derekperkins